### PR TITLE
Speclj interface requires run.standard

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  override:
+    lein spec

--- a/spec/factory_time/core_spec.clj
+++ b/spec/factory_time/core_spec.clj
@@ -1,6 +1,6 @@
 (ns factory-time.core-spec
   (:require [factory-time.core :refer :all]
-            [speclj.core :refer :all]))
+            [speclj.core :refer :all] speclj.run.standard))
 
 (deffactory :book {:author "Joe Abercrombie"})
 (deffactory :person {:name "Alex" :favorites {:food "steak" :color "red"}})

--- a/spec/factory_time/core_spec.clj
+++ b/spec/factory_time/core_spec.clj
@@ -1,6 +1,7 @@
 (ns factory-time.core-spec
   (:require [factory-time.core :refer :all]
-            [speclj.core :refer :all] speclj.run.standard))
+            [speclj.core :refer :all]
+            speclj.run.standard))
 
 (deffactory :book {:author "Joe Abercrombie"})
 (deffactory :person {:name "Alex" :favorites {:food "steak" :color "red"}})


### PR DESCRIPTION
:information_desk_person: The interface for Speclj changed in v3.0.0 and now requires `speclj.run.standard` to be loaded.

Fixes errors like:
```
Exception in thread "main" java.lang.ClassNotFoundException: speclj.components, compiling:(factory_time/core_spec.clj:19:1)
   at clojure.lang.Compiler.analyzeSeq(Compiler.java:6651)
   at clojure.lang.Compiler.analyze(Compiler.java:6445)
   at clojure.lang.Compiler.access$100(Compiler.java:38)
   at clojure.lang.Compiler$LetExpr$Parser.parse(Compiler.java:6050)
   at clojure.lang.Compiler.analyzeSeq(Compiler.java:6644)
   at clojure.lang.Compiler.analyze(Compiler.java:6445)
   at clojure.lang.Compiler.analyze(Compiler.java:6406)
   at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:5782)
   at clojure.lang.Compiler$FnMethod.parse(Compiler.java:5217)
   at clojure.lang.Compiler$FnExpr.parse(Compiler.java:3846)
   at clojure.lang.Compiler.analyzeSeq(Compiler.java:6642)
   at clojure.lang.Compiler.analyze(Compiler.java:6445)
   at clojure.lang.Compiler.eval(Compiler.java:6700)
   at clojure.lang.Compiler.load(Compiler.java:7130)
   at clojure.lang.RT.loadResourceScript(RT.java:370)
   at clojure.lang.RT.loadResourceScript(RT.java:361)
   at clojure.lang.RT.load(RT.java:440)
   at clojure.lang.RT.load(RT.java:411)
   at clojure.core$load$fn__5066.invoke(core.clj:5641)
   at clojure.core$load.doInvoke(core.clj:5640)
   at clojure.lang.RestFn.invoke(RestFn.java:408)
   at clojure.core$load_one.invoke(core.clj:5446)
   at clojure.core$load_lib$fn__5015.invoke(core.clj:5486)
   at clojure.core$load_lib.doInvoke(core.clj:5485)
   at clojure.lang.RestFn.applyTo(RestFn.java:142)
   at clojure.core$apply.invoke(core.clj:626)
   at clojure.core$load_libs.doInvoke(core.clj:5524)
   at clojure.lang.RestFn.applyTo(RestFn.java:137)
   at clojure.core$apply.invoke(core.clj:626)
   at clojure.core$require.doInvoke(core.clj:5607)
   at clojure.lang.RestFn.applyTo(RestFn.java:137)
   at clojure.core$apply.invoke(core.clj:626)
   at user$eval85.invoke(form-init1181474459183097401.clj:1)
   at clojure.lang.Compiler.eval(Compiler.java:6703)
   at clojure.lang.Compiler.eval(Compiler.java:6693)
   at clojure.lang.Compiler.load(Compiler.java:7130)
   at clojure.lang.Compiler.loadFile(Compiler.java:7086)
   at clojure.main$load_script.invoke(main.clj:274)
   at clojure.main$init_opt.invoke(main.clj:279)
   at clojure.main$initialize.invoke(main.clj:307)
   at clojure.main$null_opt.invoke(main.clj:342)
   at clojure.main$main.doInvoke(main.clj:420)
   at clojure.lang.RestFn.invoke(RestFn.java:421)
   at clojure.lang.Var.invoke(Var.java:383)
   at clojure.lang.AFn.applyToHelper(AFn.java:156)
   at clojure.lang.Var.applyTo(Var.java:700)
   at clojure.main.main(main.java:37)
Caused by: java.lang.ClassNotFoundException: speclj.components
   at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
   at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
   at java.security.AccessController.doPrivileged(Native Method)
   at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
   at clojure.lang.DynamicClassLoader.findClass(DynamicClassLoader.java:61)
   at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
   at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
   at java.lang.Class.forName0(Native Method)
   at java.lang.Class.forName(Class.java:270)
   at clojure.lang.RT.classForName(RT.java:2065)
   at clojure.lang.Compiler$HostExpr.maybeClass(Compiler.java:978)
   at clojure.lang.Compiler$HostExpr.access$400(Compiler.java:756)
   at clojure.lang.Compiler.macroexpand1(Compiler.java:6583)
   at clojure.lang.Compiler.analyzeSeq(Compiler.java:6630)

... 46 more lein trampoline test returned exit code 1
```