### PR TITLE
Add the with-ids macro

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject factory-time "0.1.1"
+(defproject factory-time "0.1.2"
   :description "A clojure repository inspired by factory_girl"
   :url "https://github.com/FundingCircle/factory-time"
   :license {:name "BSD 3-clause"

--- a/spec/factory_time/core_spec.clj
+++ b/spec/factory_time/core_spec.clj
@@ -17,6 +17,12 @@
   :create! (fn [food]
              (reset! saved-food food)))
 
+(describe "factory-time.with-ids"
+  (describe "with-ids"
+    (= (with-ids [1] [author]
+         {:author author})
+       {:author 1})))
+
 (describe "factory-time.core"
   (describe "build"
     (it "builds the base object"

--- a/src/factory_time/core.clj
+++ b/src/factory_time/core.clj
@@ -60,3 +60,21 @@
            factory# (Factory. factory-config#)]
        (defmethod get-factory ~factory-name [_#]
          factory#))))
+
+(defmacro with-ids [seqable id-vars & body]
+  "Generate named identities
+
+   Intended to help link together related entities. For example, to associate multiple
+   book entities with their author, one could use:
+
+   ```
+   (with-ids [[1] author]
+     (build :author {:id author :name \"Irvine Welsh\"})
+     (build :book {:author author :name \"Trainspotting\"})
+     (build :book {:author author :name \"Acid House\"}))
+   ```
+
+   This makes it easier to specify groups of related entities to be used together in
+   fixtures."
+  `(let ~(into [] (apply concat (map vector id-vars seqable)))
+     ~@body))


### PR DESCRIPTION
`with-ids` is intended to help link together related entities. For
example, to associate multiple book entities with their author, one
could use:

   ```
   (with-ids [[1] author]
     (build :author {:id author :name \"Irvine Welsh\"})
     (build :book {:author author :name \"Trainspotting\"})
     (build :book {:author author :name \"Acid House\"}))
   ```

This makes it easier to specify groups of related entities to be used
together in fixtures."