### PR TITLE
Update project to reflect new license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Factory Time
+[![Circle CI](https://circleci.com/gh/FundingCircle/factory-time/tree/master.svg?style=svg)](https://circleci.com/gh/FundingCircle/factory-time/tree/master)
+[![Downloads](https://jarkeeper.com/FundingCircle/factory-time/downloads.svg)](https://jarkeeper.com/FundingCircle/factory-time)
+[![Dependencies Status](https://jarkeeper.com/FundingCircle/factory-time/status.svg)](https://jarkeeper.com/FundingCircle/factory-time)
 
 Factory Time is a Clojure library for maintaining test data, similar to [Fabricator](http://www.fabricationgem.org/) for Ruby. Read more about the motivation for Factory Time on our [blog](https://engineering.fundingcircle.com/blog/2015/03/21/factory-time/).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Factory Time is a Clojure library for maintaining test data, similar to [Fabrica
 
 ## Leiningen
 
-`[factory-time "0.1.1"]`
+`[factory-time "0.1.2"]`
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject factory-time "0.1.1"
+(defproject factory-time "0.1.2"
   :description "A clojure repository inspired by factory_girl"
   :url "https://github.com/FundingCircle/factory-time"
   :license {:name "BSD 3-clause"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/FundingCircle/factory-time"
   :license {:name "BSD 3-clause"
             :url "http://opensource.org/licenses/BSD-3-Clause"}
-  :dependencies [[org.clojure/clojure "1.6.0"]]
-  :profiles {:dev {:dependencies [[speclj "3.1.0"]]}}
-  :plugins [[speclj "3.1.0"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]]
+  :profiles {:dev {:dependencies [[speclj "3.3.2"]]}}
+  :plugins [[speclj "3.3.2"]]
   :test-paths ["spec"])

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject factory-time "0.1.2"
-  :description "A clojure repository inspired by factory_girl"
+  :description "A Clojure library inspired by factory_girl"
   :url "https://github.com/FundingCircle/factory-time"
   :license {:name "BSD 3-clause"
             :url "http://opensource.org/licenses/BSD-3-Clause"}


### PR DESCRIPTION
💁  Clojars [lists the previous license against the current release of this library (v0.1.1)](https://clojars.org/factory-time/versions/0.1.1), which is incorrect. These changes update the project version so that Clojars to picks up the correct license attached to this project.

Also took the time to update the project dependencies (🚧 ) and add some status badges (💄 ).