### PR TITLE
Automatically tag and deploy artifacts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,12 @@
 test:
   override:
     - lein spec
+
+deployment:
+  clojars:
+    branch: master
+    owner: FundingCircle
+    commands:
+      - git config --global user.email "circleci@circleci.com"
+      - git config --global user.name "CircleCI"
+      - lein do deploy, vcs tag --no-sign :prefix "v", vcs push

--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,14 @@
   :dependencies [[org.clojure/clojure "1.8.0"]]
   :profiles {:dev {:dependencies [[speclj "3.3.2"]]}}
   :plugins [[speclj "3.3.2"]]
+  :repositories [["releases"
+                  {:url "https://clojars.org/repo"
+                   :sign-releases false
+                   :username [:gpg :env/clojars_user]
+                   :password [:gpg :env/clojars_password]}]
+                 ["snapshots"
+                  {:url "https://clojars.org/repo"
+                   :sign-releases false
+                   :username [:gpg :env/clojars_user]
+                   :password [:gpg :env/clojars_password]}]]
   :test-paths ["spec"])


### PR DESCRIPTION
💁  These changes leverage CircleCI's `deployment` stage to tag and deploy artifacts to Clojars after a merge to master successfully builds.